### PR TITLE
Deprecate Sphinx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -187,7 +187,7 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.4
     # via beautifulsoup4
-sphinx==6.1.3
+sphinx==5.3.0
     # via
     #   citecheck (pyproject.toml)
     #   pydata-sphinx-theme


### PR DESCRIPTION
Dependabot needs to be configured to work properly with pip-compile.